### PR TITLE
Update tilelive

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimist": "^1.1.0",
     "queue-async": "^1.0.7",
     "s3urls": "^1.3.0",
-    "tilelive": "~5.11.0",
+    "tilelive": "~5.12.2",
     "tilelive-s3": "^6.2.0"
   }
 }


### PR DESCRIPTION
Updates tilelive to the 5.12 track

cc/ @GretaCB @mapsam 

Should we publish mapbox-grid-copy at `1.2.1` or `1.3.0`?